### PR TITLE
MTAVX512

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -20,9 +20,9 @@ void lcg_nist_test(size_t count_number) {
     nist_test.test(true);
 }
 
-bool check_correct(size_t count_number) {
+bool check_correct_avx2(size_t count_number) {
     MT19937 right_gen;
-    MersenneTwister32AVX2 gen;
+    MT32AVX2 gen;
     size_t count = 0;
     for (size_t i = 0; i < count_number; i++) {
         uint32_t right = right_gen();
@@ -36,7 +36,7 @@ bool check_correct(size_t count_number) {
     return count == 0;
 }
 
-void benchmark_generate(size_t count_number) {
+void benchmark_generate_avx2(size_t count_number) {
     MT19937 right_gen;
     auto begin = std::chrono::steady_clock::now();
     for (size_t i = 0; i < count_number; i++) {
@@ -44,18 +44,18 @@ void benchmark_generate(size_t count_number) {
     }
     auto elapsed =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
-    std::cout << "Fill with MT19937: " << elapsed << " ms" << std::endl;
+    std::cout << "Generate with MT19937: " << elapsed << " ms" << std::endl;
 
-    MersenneTwister32AVX2 gen;
+    MT32AVX2 gen;
     begin = std::chrono::steady_clock::now();
     for (size_t i = 0; i < count_number; i++) {
         gen();
     }
     elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
-    std::cout << "Fill with MT19937AVX2: " << elapsed << " ms" << std::endl;
+    std::cout << "Generate with MT19937AVX2: " << elapsed << " ms" << std::endl;
 }
 
-void benchmark_generate_array(size_t count_number) {
+void benchmark_generate_array_avx2(size_t count_number) {
     MT19937 right_gen;
     std::vector<uint32_t> array_right(count_number);
     auto begin = std::chrono::steady_clock::now();
@@ -66,7 +66,7 @@ void benchmark_generate_array(size_t count_number) {
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
     std::cout << "Fill with MT19937: " << elapsed << " ms" << std::endl;
 
-    MersenneTwister32AVX2 gen;
+    MT32AVX2 gen;
     std::vector<uint32_t> array(count_number);
     begin = std::chrono::steady_clock::now();
     gen.generate_bulk(array.data(), array.size());
@@ -80,12 +80,125 @@ void benchmark_generate_array(size_t count_number) {
     }
 }
 
+bool check_correct_avx512(size_t count_number) {
+    MT19937 right_gen;
+    MT32AVX512 gen;
+    size_t count = 0;
+    for (size_t i = 0; i < count_number; i++) {
+        uint32_t right = right_gen();
+        uint32_t value = gen();
+        if (right != value) {
+            std::cout << "i = " << i << " Different value " << right << " != " << value << std::endl;
+            count++;
+        }
+    }
+    std::cout << "Different numbers: " << count << std::endl;
+    return count == 0;
+}
+
+void benchmark_generate_avx512(size_t count_number) {
+    MT19937 right_gen;
+    auto begin = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < count_number; i++) {
+        right_gen();
+    }
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Generate with MT19937: " << elapsed << " ms" << std::endl;
+
+    MT32AVX512 gen;
+    begin = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < count_number; i++) {
+        gen();
+    }
+    elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Generate with MT19937AVX512: " << elapsed << " ms" << std::endl;
+}
+
+void benchmark_generate_array_avx512(size_t count_number) {
+    MT19937 right_gen;
+    std::vector<uint32_t> array_right(count_number);
+    auto begin = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < count_number; i++) {
+        array_right[i] = right_gen();
+    }
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Fill with MT19937: " << elapsed << " ms" << std::endl;
+
+    MT32AVX512 gen;
+    std::vector<uint32_t> array(count_number);
+    begin = std::chrono::steady_clock::now();
+    gen.generate_bulk(array.data(), array.size());
+    elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Fill with MT19937AVX512: " << elapsed << " ms" << std::endl;
+
+    for (size_t i = 0; i < count_number; i++) {
+        if (array_right[i] != array[i]) {
+            std::cout << "i = " << i << " Diff value " << array_right[i] << " != " << array[i] << std::endl;
+        }
+    }
+}
+
+void benchmark_generate_avx2_vs_avx512(size_t count_number) {
+    MT32AVX2 right_gen;
+    auto begin = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < count_number; i++) {
+        right_gen();
+    }
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Generate with MT19937AVX2: " << elapsed << " ms" << std::endl;
+
+    MT32AVX512 gen;
+    begin = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < count_number; i++) {
+        gen();
+    }
+    elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Generate with MT19937AVX512: " << elapsed << " ms" << std::endl;
+}
+
+void benchmark_generate_array_avx2_vs_avx512(size_t count_number) {
+    MT32AVX2 right_gen;
+    std::vector<uint32_t> array_right(count_number);
+    auto begin = std::chrono::steady_clock::now();
+    right_gen.generate_bulk(array_right.data(), array_right.size());
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Fill with MT19937AVX2: " << elapsed << " ms" << std::endl;
+
+    MT32AVX512 gen;
+    std::vector<uint32_t> array(count_number);
+    begin = std::chrono::steady_clock::now();
+    gen.generate_bulk(array.data(), array.size());
+    elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+    std::cout << "Fill with MT19937AVX512: " << elapsed << " ms" << std::endl;
+
+    for (size_t i = 0; i < count_number; i++) {
+        if (array_right[i] != array[i]) {
+            std::cout << "i = " << i << " Diff value " << array_right[i] << " != " << array[i] << std::endl;
+        }
+    }
+}
+
 int main() {
     // std::size_t count_number = 1'000'000'000;
     // std::size_t count_number = 1'000'000'111;
     // std::size_t count_number = 100'000;
-    // check_correct(count_number);
-    // benchmark_generate(count_number);
-    // benchmark_generate_array(count_number);
+
+    // AVX2
+    // check_correct_avx2(count_number);
+    // benchmark_generate_avx2(count_number);
+    // benchmark_generate_array_avx2(count_number);
+
+    // AVX512
+    // check_correct_avx512(count_number);
+    // benchmark_generate_avx512(count_number);
+    // benchmark_generate_array_avx512(count_number);
+
+    // AVX vs AVX512
+    // benchmark_generate_avx2_vs_avx512(count_number);
+    // benchmark_generate_array_avx2_vs_avx512(count_number);
     return 0;
 }

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -17,4 +17,4 @@ target_include_directories(${TARGET_NAME} PUBLIC
     include
 )
 
-target_compile_options(generators PRIVATE -mavx2 -mfma -mavx512vl)
+target_compile_options(generators PRIVATE -O3 -mavx2 -mfma -mavx512f -mavx512vl -mavx512ifma)

--- a/generators/include/generators/mersenne_twister_simd.hpp
+++ b/generators/include/generators/mersenne_twister_simd.hpp
@@ -47,3 +47,45 @@ class MersenneTwister32AVX2 : public Generator<uint32_t> {
 };
 
 using MT32AVX2 = MersenneTwister32AVX2;
+
+class MersenneTwister32AVX512 : public Generator<uint32_t> {
+  private:
+    static constexpr size_t W = 32UL;
+    static constexpr size_t N = 624UL;
+    static constexpr size_t M = 397UL;
+    static constexpr size_t R = 31UL;
+    static constexpr size_t A = 0x9908b0dfUL;
+    static constexpr size_t U = 11UL;
+    static constexpr size_t D = 0xffffffffUL;
+    static constexpr size_t S = 7UL;
+    static constexpr size_t B = 0x9d2c5680UL;
+    static constexpr size_t T = 15UL;
+    static constexpr size_t C = 0xefc60000UL;
+    static constexpr size_t L = 18UL;
+    static constexpr size_t F = 1812433253UL;
+    static constexpr uint32_t default_seed = 5489u;
+    static constexpr uint32_t UPPER_MASK = (~uint32_t()) << R;
+    static constexpr uint32_t LOWER_MASK = ~UPPER_MASK;
+
+    alignas(64) std::array<uint32_t, N> mt;
+    size_t index_state;
+
+    void twist();
+
+    // Векторизованное преобразование tempering
+    __m512i tempering_simd(__m512i value) const;
+
+    // Скалярное преобразование tempering
+    uint32_t tempering_scalar(uint32_t value) const;
+
+  public:
+    MersenneTwister32AVX512(const uint32_t &seed = default_seed);
+
+    virtual uint32_t operator()() override;
+    virtual uint32_t min() const override;
+    virtual uint32_t max() const override;
+
+    void generate_bulk(uint32_t *output, size_t len);
+};
+
+using MT32AVX512 = MersenneTwister32AVX512;

--- a/generators/src/mersenne_twister_simd.cpp
+++ b/generators/src/mersenne_twister_simd.cpp
@@ -124,3 +124,125 @@ uint32_t MersenneTwister32AVX2::min() const {
 uint32_t MersenneTwister32AVX2::max() const {
     return std::numeric_limits<uint32_t>::max();
 }
+
+// TODO: Move in utils
+void print_m512(const __m512i &vec) {
+    uint32_t values[16];
+    _mm512_store_si512((__m512i *)values, vec);
+
+    for (int i = 0; i < 16; i++) {
+        std::cout << values[i] << " " << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+MersenneTwister32AVX512::MersenneTwister32AVX512(const uint32_t &seed) {
+    mt[0] = seed;
+    for (size_t i = 1; i < N; i++) {
+        mt[i] = (F * (mt[i - 1] ^ (mt[i - 1] >> (W - 2))) + i);
+    }
+    index_state = N;
+}
+
+__m512i MersenneTwister32AVX512::tempering_simd(__m512i y) const {
+    y = _mm512_xor_si512(y, _mm512_and_si512(_mm512_srli_epi32(y, U), _mm512_set1_epi32(D)));
+    y = _mm512_xor_si512(y, _mm512_and_si512(_mm512_slli_epi32(y, S), _mm512_set1_epi32(B)));
+    y = _mm512_xor_si512(y, _mm512_and_si512(_mm512_slli_epi32(y, T), _mm512_set1_epi32(C)));
+    y = _mm512_xor_si512(y, _mm512_srli_epi32(y, L));
+    return y;
+}
+
+uint32_t MersenneTwister32AVX512::tempering_scalar(uint32_t y) const {
+    y ^= (y >> U) & D;
+    y ^= (y << S) & B;
+    y ^= (y << T) & C;
+    y ^= (y >> L);
+    return y;
+}
+
+void MersenneTwister32AVX512::twist() {
+    const __m512i upper_mask = _mm512_set1_epi32(UPPER_MASK);
+    const __m512i lower_mask = _mm512_set1_epi32(LOWER_MASK);
+    const __m512i one = _mm512_set1_epi32(1);
+
+    size_t i = 0;
+    size_t j = M;
+    for (; i + 16 <= N && j + 16 <= N; i += 16, j += 16) {
+        __m512i mt_i = _mm512_load_si512((__m512i *)&mt[i]);
+        __m512i mt_i1 = _mm512_loadu_si512((__m512i *)&mt[i + 1]);
+        __m512i x = _mm512_or_si512(_mm512_and_si512(mt_i, upper_mask), _mm512_and_si512(mt_i1, lower_mask));
+
+        __m512i xA = _mm512_srli_epi32(x, 1);
+
+        __mmask16 mask = _mm512_test_epi32_mask(x, one);
+        xA = _mm512_mask_xor_epi32(xA, mask, xA, _mm512_set1_epi32(A));
+
+        __m512i mt_im = _mm512_loadu_si512((__m512i *)&mt[j]);
+        __m512i res = _mm512_xor_si512(mt_im, xA);
+
+        _mm512_storeu_si512((__m512i *)&mt[i], res);
+    }
+    for (; i + 16 <= N && j < N; j++, i++) {
+        size_t x = (mt[i] & UPPER_MASK) | (mt[(i + 1) % N] & LOWER_MASK);
+        mt[i] = mt[j] ^ (x >> 1) ^ ((x & 1) ? A : 0);
+    }
+    j = 0;
+    for (; i + 16 <= N && j + 16 <= N; i += 16, j += 16) {
+        __m512i mt_i = _mm512_loadu_si512((__m512i *)&mt[i]);
+        __m512i mt_i1 = _mm512_loadu_si512((__m512i *)&mt[i + 1]);
+        __m512i x = _mm512_or_si512(_mm512_and_si512(mt_i, upper_mask), _mm512_and_si512(mt_i1, lower_mask));
+
+        __m512i xA = _mm512_srli_epi32(x, 1);
+
+        __mmask16 mask = _mm512_test_epi32_mask(x, one);
+        xA = _mm512_mask_xor_epi32(xA, mask, xA, _mm512_set1_epi32(A));
+
+        __m512i mt_im = _mm512_loadu_si512((__m512i *)&mt[j]);
+        __m512i res = _mm512_xor_si512(mt_im, xA);
+
+        _mm512_storeu_si512((__m512i *)&mt[i], res);
+    }
+
+    for (; i < N; i++) {
+        size_t x = (mt[i] & UPPER_MASK) | (mt[(i + 1) % N] & LOWER_MASK);
+        mt[i] = mt[(i + M) % N] ^ (x >> 1) ^ ((x & 1) ? A : 0);
+    }
+    index_state = 0;
+}
+
+uint32_t MersenneTwister32AVX512::operator()() {
+    if (index_state >= N) {
+        twist();
+    }
+    return tempering_scalar(mt[index_state++]);
+}
+
+void MersenneTwister32AVX512::generate_bulk(uint32_t *output, size_t len) {
+    size_t j = 0;
+    size_t i = 0;
+    for (i = 0, j = 0; i + 16 <= len; i += 16, j += 16) {
+        if (index_state >= N) {
+            twist();
+            j = 0;
+        }
+        __m512i data = _mm512_load_si512((__m512i *)&mt[j]);
+        _mm512_storeu_si512((__m512i *)&output[i], tempering_simd(data));
+        index_state += 16;
+    }
+    for (; i < len; i++, j++) {
+        if (index_state >= N) {
+            twist();
+            j = 0;
+        }
+        output[i] = tempering_scalar(mt[j]);
+        index_state += 1;
+    }
+}
+
+uint32_t MersenneTwister32AVX512::min() const {
+    return 0u;
+}
+
+uint32_t MersenneTwister32AVX512::max() const {
+    return std::numeric_limits<uint32_t>::max();
+}

--- a/tests/MT/mt_tests.cpp
+++ b/tests/MT/mt_tests.cpp
@@ -1115,3 +1115,12 @@ TEST(MT32AVX2, can_generate_correct_seq) {
         ASSERT_EQ(correct_generator(), my_generator());
     }
 }
+
+TEST(MT32AVX512, can_generate_correct_seq) {
+    GTEST_SKIP();
+    MT19937 correct_generator;
+    MT32AVX512 my_generator;
+    for (size_t i = 0; i < 1'000'000; i++) {
+        ASSERT_EQ(correct_generator(), my_generator());
+    }
+}


### PR DESCRIPTION
Implemented SIMD MT32AVX512 only with N = 624;

```
Generate with MT19937AVX2: 1715 ms
Generate with MT19937AVX512: 1624 ms
Speed up: ~6% 
```